### PR TITLE
Write errors to stderr

### DIFF
--- a/main/erg.go
+++ b/main/erg.go
@@ -55,7 +55,7 @@ func main() {
 
 	result, err := e.Expand(query)
 	if err != nil {
-		fmt.Println("Error: ", err.Error())
+		fmt.Fprintln(os.Stderr, "Error: ", err.Error())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Use stderr to display errors receieved from the range server. With this
change, stdout only gets data.